### PR TITLE
Bugfix for PDF receipts and support for html and text content-types

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 Simple python script to fetch all Letters and Receipts from Kivra down to a local folder for backup purposes.
 
-##
-Dependencies
+## Dependencies
 ```
-pip install requests qrcode Pillow
+requests qrcode Pillow weasyprint
 ```

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # fetch-kivra
 
 Simple python script to fetch all Letters and Receipts from Kivra down to a local folder for backup purposes.
+
+##
+Dependencies
+```
+pip install requests qrcode Pillow
+```

--- a/fetch-kivra.py
+++ b/fetch-kivra.py
@@ -62,6 +62,8 @@ ssn = sys.argv[1]
 # Konfiguration
 FETCH_RECEIPTS = True  # Sätt till True för att hämta kvitton
 FETCH_LETTERS = True    # Sätt till True för att hämta brev
+MAX_RECEIPTS = None    # Sätt till ett heltal för att begränsa antalet kvitton som hämtas (None = obegränsat)
+MAX_LETTERS = None     # Sätt till ett heltal för att begränsa antalet brev som hämtas (None = obegränsat)
 
 # Uppdaterad BankID-initiering och QR-hantering
 def display_qr_code(qr_data):
@@ -339,6 +341,11 @@ try:
                 with open(receipts_json_path, 'w', encoding='utf-8') as f:
                     json.dump(receipts, f, ensure_ascii=False, indent=2)
                 print(f"Sparade kvittolista till {receipts_json_path}")
+                
+                # Begränsa antalet kvitton om MAX_RECEIPTS är satt
+                if MAX_RECEIPTS is not None:
+                    print(f"\nBegränsar till {MAX_RECEIPTS} kvitton (av {len(receipt_list)} tillgängliga)")
+                    receipt_list = receipt_list[:MAX_RECEIPTS]
                 
                 # Iterera över varje kvitto
                 print("\nHämtar detaljerad information och PDF för varje kvitto...")
@@ -746,6 +753,11 @@ try:
                     json.dump({"total": total_letters, "list": all_letters}, f, ensure_ascii=False, indent=2)
                 print(f"Sparade brevlista till {letters_json_path}")
                 
+                # Begränsa antalet brev om MAX_LETTERS är satt
+                if MAX_LETTERS is not None:
+                    print(f"\nBegränsar till {MAX_LETTERS} brev (av {len(all_letters)} tillgängliga)")
+                    all_letters = all_letters[:MAX_LETTERS]
+                
                 # Iterera över varje brev för att hämta PDF och detaljer
                 print("\nHämtar PDF och detaljer för varje brev...")
                 for letter in all_letters:
@@ -866,9 +878,3 @@ try:
     os.remove(temp_path)
 except:
     pass
-
-
-
-
-
-

--- a/fetch-kivra.py
+++ b/fetch-kivra.py
@@ -625,7 +625,8 @@ try:
                     # 3. Hämta och spara PDF direkt under Receipts
                     pdf_url = f"https://app.api.kivra.com/v1/user/{actor_key}/receipts/{receipt_key}"
                     pdf_headers = {
-                        'Authorization': f'token {access_token}'
+                        'Authorization': f'token {access_token}',
+                        'Accept': 'application/pdf'
                     }
                     
                     logging.debug(f"PDF Headers: {pdf_headers}")


### PR DESCRIPTION
This PR contains various changes separated into commits, feel free to cherry pick commits if the full PR is not interesting as a whole.

I have

1. Added a note to the README about dependencies.
2. Added `Accept`-header to the receipt PDF-request. When I ran the tool locally, without this change, I ended up with corrupt PDF-receipts, the files actually contained plaintext JSON.
3. MAX_LETTERS and MAX_RECEIPTS allow the user to limit the number of files files downloaded of each type, mostly useful for testing.
4. Store any "text/plain" parts as .txt-files and "text/html" as PDFs. Largest change, introduces dependency on weasyprint, a bit of a pain to get going on MacOS. Works for most HTML-messages but crashes for me on two messages from Kivra Företag that use a fairly sophisticated CSS-styling. In case of a crash it catches the exception and stores the html-source as a .html-document instead.

Open to feedback or suggestions. Not sure if you are looking for contributions, but thought I'd open a PR since I had the code running.